### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pod 'MKPolygon-GPC', '~> 0.0.1'
 2) Refresh your project pods ```pod install```
 
 ### Manually
-If you're not using cocoapods, just add `MKPolygon+GPC.h`, `MKPolygon+GPC.m`, `gpc.h` & `gpc.c` in your XCode project.
+If you're not using cocoapods, just add `MKPolygon+GPC.h`, `MKPolygon+GPC.m`, `gpc.h` & `gpc.c` in your Xcode project.
 
 ## Usage
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
