### PR TITLE
Fixed crash on gpcPolygon nil

### DIFF
--- a/MKPolygon-GPC-Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/MKPolygon-GPC-Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/MKPolygon-GPC-Example/MKPolygon-GPC/MKPolygon+GPC.m
+++ b/MKPolygon-GPC-Example/MKPolygon-GPC/MKPolygon+GPC.m
@@ -52,7 +52,8 @@
 + (MKPolygon *) polygonWithGPCPolygon:(gpc_polygon *) gpcPolygon interiorPolygons:(NSArray *)interiorPolygons
 {
 	NSAssert( gpcPolygon != NULL, @"attempt to create path from NULL gpcPolygon");
-	
+    if (gpcPolygon->contour == NULL) return nil;
+
 	NSUInteger vertCount = gpcPolygon->contour[0].num_vertices;
 	
 	if (vertCount == 0) return nil;


### PR DESCRIPTION
When importing your library in my swift project, I wanted to use the union method which resolved as a crash because gpcPolycon->contour was NULL .

Adding a check solved the issue for me . 
